### PR TITLE
Part2 Branch: Port Fix

### DIFF
--- a/backend/tancho/config/config.sample.yml
+++ b/backend/tancho/config/config.sample.yml
@@ -11,4 +11,4 @@ databases:
     USER: 'tancho_user'
     PASSWORD: '4dm1n4dm1n'
     HOST: 'mongo'
-    PORT: '27017'
+    PORT: 27017


### PR DESCRIPTION
It looks like you had a more elegant fix in the next parts, but branch2 and your corresponding Medium article @ [https://medium.com/@bruno.fosados/simple-learn-docker-fastapi-and-vue-js-second-part-backend-fastapi-cec2e1e093a9](https://medium.com/@bruno.fosados/simple-learn-docker-fastapi-and-vue-js-second-part-backend-fastapi-cec2e1e093a9) still have config that throws port error from mongoclient when port is listed as a string in the yml